### PR TITLE
Replace kubernetes-client with got

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -34,10 +34,9 @@ keyPairManager.ensureKeys().then((keys) => {
   proxy.init(keys);
   proxy.connect();
 }).catch((reason) => {
-  logger.error("[MAIN] failed to create certificates", reason);
+  logger.error("[MAIN] failed to create certificates %s", reason);
   process.exit(1);
 });
-
 
 process.once("SIGTERM", () => {
   proxy.disconnect();

--- a/src/__tests__/keypair-manager.test.ts
+++ b/src/__tests__/keypair-manager.test.ts
@@ -3,7 +3,7 @@ import { KeyPairManager } from "../keypair-manager";
 describe("KeyPairManager", () => {
   describe("generateKeys", () => {
     it("generates keys", async () => {
-      const manager = new KeyPairManager("default", {} as any);
+      const manager = new KeyPairManager("default");
 
       const keys = await manager.generateKeys();
 

--- a/src/__tests__/stream-parser.test.ts
+++ b/src/__tests__/stream-parser.test.ts
@@ -5,7 +5,7 @@ import { publicEncrypt, randomBytes } from "crypto";
 
 describe("StreamParser", () => {
   it ("parses bored header", async () => {
-    const keyPairManager = new KeyPairManager("default", {} as any);
+    const keyPairManager = new KeyPairManager("default");
     const stream = new PassThrough();
     const parser = new StreamParser();
     const keys = await keyPairManager.generateKeys();
@@ -29,7 +29,7 @@ describe("StreamParser", () => {
   });
 
   it ("ignores invalid header value", async () => {
-    const keyPairManager = new KeyPairManager("default", {} as any);
+    const keyPairManager = new KeyPairManager("default");
     const stream = new PassThrough();
     const parser = new StreamParser();
     const keys = await keyPairManager.generateKeys();

--- a/src/keypair-manager.ts
+++ b/src/keypair-manager.ts
@@ -70,6 +70,7 @@ export class KeyPairManager {
   }
 
   async ensureKeys(): Promise<KeyPair> {
+    await this.apiClient.init();
     const existingKeys = await this.fetchExistingKeys();
 
     if (existingKeys.private !== "" && existingKeys.public !== "") {


### PR DESCRIPTION
Reason: we need only really small subset of Kubernetes api and the official client is heavy. This will save almost 40% memory on idle (better for IoT).