### PR TITLE
Fix port-forward (connect upgrade) bug

### DIFF
--- a/src/__tests__/__snapshots__/stream-impersonator.test.ts.snap
+++ b/src/__tests__/__snapshots__/stream-impersonator.test.ts.snap
@@ -76,6 +76,33 @@ Impersonate-User: johndoe
 {\\"apiVersion\\":\\"authorization.k8s.io/v1\\",\\"kind\\":\\"SelfSubjectAccessReview\\",\\"spec\\":{\\"resourceAttributes\\":{\\"namespace\\":\\"kube-system\\",\\"resource\\":\\"*\\",\\"verb\\":\\"create\\"}}}{\\"apiVersion\\":\\"authorization.k8s.io/v1\\",\\"kind\\":\\"SelfSubjectAccessReview\\",\\"spec\\":{\\"resourceAttributes\\":{\\"namespace\\":\\"kube-system\\",\\"resource\\":\\"*\\",\\"verb\\":\\"create\\"}}}"
 `;
 
+exports[`StreamImpersonator handles port-forward upgrade 1`] = `
+"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Content-Length: 0
+Connection: Upgrade
+Authorization: Bearer service-account-token
+Impersonate-User: johndoe
+
+GET /version HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjYxOTA3ODcsInN1YiI6ImpvaG5kb2UiLCJhdWQiOlsiaHR0cDovL2JvcmVkOjY2NjYiXSwiaWF0IjoxNjI2MTg3MTg3fQ.FxaoYXJUK7lrousxq2MbDSrjfpTHxAy5zfdYuLwUMlbRCqtG1d59mhSy5Ws4LULYsIOSfeJ6VofMY-MZKbi7Cf7CNlfyHv5o1ZQoztv8kME9ydCy2Q1bBqw2IcffNz7xFDFYjqMftKamDn1v6R5EI315yGkj3ot4HtFAhj-IDizi69zlQtkmXHP0otktCVO_7STDsZbSql9fD_PGto8V1vS3tzad3mekwU6UAM2pBJtNdWn0HFeNqpNEGG-2oUChqy_dsQ7YquXkcXKqNs1RwE-bvSVwKr-5nVEDN4UEdZnDH61F3tKDd7wrZps3m8oIYjrMrikBtnDQNyEXcgFpSw
+
+POST /foo HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjYxOTA3ODcsInN1YiI6ImpvaG5kb2UiLCJhdWQiOlsiaHR0cDovL2JvcmVkOjY2NjYiXSwiaWF0IjoxNjI2MTg3MTg3fQ.FxaoYXJUK7lrousxq2MbDSrjfpTHxAy5zfdYuLwUMlbRCqtG1d59mhSy5Ws4LULYsIOSfeJ6VofMY-MZKbi7Cf7CNlfyHv5o1ZQoztv8kME9ydCy2Q1bBqw2IcffNz7xFDFYjqMftKamDn1v6R5EI315yGkj3ot4HtFAhj-IDizi69zlQtkmXHP0otktCVO_7STDsZbSql9fD_PGto8V1vS3tzad3mekwU6UAM2pBJtNdWn0HFeNqpNEGG-2oUChqy_dsQ7YquXkcXKqNs1RwE-bvSVwKr-5nVEDN4UEdZnDH61F3tKDd7wrZps3m8oIYjrMrikBtnDQNyEXcgFpSw
+
+barGET /foo HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjYxOTA3ODcsInN1YiI6ImpvaG5kb2UiLCJhdWQiOlsiaHR0cDovL2JvcmVkOjY2NjYiXSwiaWF0IjoxNjI2MTg3MTg3fQ.FxaoYXJUK7lrousxq2MbDSrjfpTHxAy5zfdYuLwUMlbRCqtG1d59mhSy5Ws4LULYsIOSfeJ6VofMY-MZKbi7Cf7CNlfyHv5o1ZQoztv8kME9ydCy2Q1bBqw2IcffNz7xFDFYjqMftKamDn1v6R5EI315yGkj3ot4HtFAhj-IDizi69zlQtkmXHP0otktCVO_7STDsZbSql9fD_PGto8V1vS3tzad3mekwU6UAM2pBJtNdWn0HFeNqpNEGG-2oUChqy_dsQ7YquXkcXKqNs1RwE-bvSVwKr-5nVEDN4UEdZnDH61F3tKDd7wrZps3m8oIYjrMrikBtnDQNyEXcgFpSw
+
+"
+`;
+
 exports[`StreamImpersonator impersonates groups on valid jwt token 1`] = `
 "GET / HTTP/1.1
 Accept: application/json

--- a/src/__tests__/stream-impersonator.test.ts
+++ b/src/__tests__/stream-impersonator.test.ts
@@ -196,6 +196,30 @@ MwIDAQAB
     expect(destination.buffer.toString()).toMatchSnapshot();
   });
 
+  it ("handles port-forward upgrade", async () => {
+    const stream = new PassThrough();
+    const parser = new StreamImpersonator();
+    const destination = new DummyWritable();
+
+    parser.boredServer = boredServer;
+    parser.saToken = "service-account-token";
+    parser.publicKey = jwtPublicKey;
+
+    const token = jwt.sign({
+      exp: Math.floor(Date.now() / 1000) + (60 * 60),
+      sub: "johndoe",
+      aud: [boredServer]
+    }, jwtPrivateKey, { algorithm: "RS256" });
+
+    stream.pipe(parser).pipe(destination);
+    stream.write(`POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews HTTP/1.1\r\nAccept: application/json\r\nContent-Type:`);
+    stream.write(` application/json\r\nContent-Length: 0\r\nConnection: Upgrade\r\nAuthorization: Bearer ${token}\r\n\r\n`);
+    stream.write(`GET /version HTTP/1.1\r\nAccept: application/json\r\nContent-Type: application/json\r\nAuthorization: Bearer ${token}\r\n\r\n`);
+    stream.write(`POST /foo HTTP/1.1\r\nAccept: application/json\r\nContent-Type: application/json\r\nAuthorization: Bearer ${token}\r\n\r\nbar`);
+    stream.write(`GET /foo HTTP/1.1\r\nAccept: application/json\r\nContent-Type: application/json\r\nAuthorization: Bearer ${token}\r\n\r\n`);
+    expect(destination.buffer.toString()).toMatchSnapshot();
+  });
+
   it("does not impersonate on invalid token", async () => {
     const stream = new PassThrough();
     const parser = new StreamImpersonator();

--- a/src/stream-impersonator.ts
+++ b/src/stream-impersonator.ts
@@ -12,6 +12,7 @@ type TokenPayload = {
 export class StreamImpersonator extends Transform {
   static newlineBuffer = Buffer.from("\r\n");
   static bodySeparatorBuffer = Buffer.from("\r\n\r\n");
+  static connectionUpgradeBuffer = Buffer.from("Connection: Upgrade");
   static authorizationSearch = "Authorization: Bearer ";
   static maxHeaderSize = 80 * 1024;
   static verbs = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"];
@@ -51,7 +52,10 @@ export class StreamImpersonator extends Transform {
     }
 
     this.httpHeadersEnded = true;
-    this.httpHeadersStarted = false;
+
+    if (headerBuffer.indexOf(StreamImpersonator.connectionUpgradeBuffer) === -1) {
+      this.httpHeadersStarted = false;
+    }
 
     const jwtToken = this.parseTokenFromHttpHeaders(headerBuffer);
 


### PR DESCRIPTION
Impersonator needs to stop parsing headers if it sees `Connection: Upgrade` header.