### PR TITLE
Add python3 to Dockerfile build section

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:16-alpine as build
 RUN mkdir /app
 WORKDIR /app
 COPY . /app
-RUN apk add --update gcc g++ make && \
+RUN apk add --update gcc g++ make python3 && \
     yarn install --frozen-lockfile && \
     yarn dist && \
     yarn install --frozen-lockfile --prod


### PR DESCRIPTION
Fixes following warning during docker build:

```
warning Error running install script for optional dependency: "/app/node_modules/msgpackr-extract: Command failed.
Exit code: 1
Command: node-gyp-build
Arguments:
Directory: /app/node_modules/msgpackr-extract
Output:
gyp info it worked if it ends with ok
gyp info using node-gyp@7.1.2
gyp info using node@16.7.0 | linux | x64
gyp ERR! find Python
gyp ERR! find Python Python is not set from command line or npm configuration
gyp ERR! find Python Python is not set from environment variable PYTHON
```

Might improve msgpack performance a bit.