### PR TITLE
Fix KUBERNETES_SERVICE_PORT env handling

### DIFF
--- a/src/agent-proxy.ts
+++ b/src/agent-proxy.ts
@@ -10,6 +10,7 @@ import { KeyPair } from "./keypair-manager";
 import { StreamParser } from "./stream-parser";
 import { StreamImpersonator } from "./stream-impersonator";
 import logger from "./logger";
+import { kubernetesPort, kubernetesHost } from "./k8s-client";
 
 export type AgentProxyOptions = {
   boredServer: string;
@@ -264,8 +265,8 @@ export class AgentProxy {
 
   handleDefaultRequestStream(stream: Stream) {
     const opts: tls.ConnectionOptions = {
-      host: process.env.KUBERNETES_HOST || "kubernetes.default.svc",
-      port: parseInt(process.env.KUBERNETES_SERVICE_PORT || "443"),
+      host: kubernetesHost,
+      port: kubernetesPort,
       timeout: 1_000 * 60 * 30 // 30 minutes
     };
 

--- a/src/k8s-client.ts
+++ b/src/k8s-client.ts
@@ -2,6 +2,7 @@ import got, { Headers } from "got";
 import * as fs from "fs/promises";
 
 export const kubernetesHost = process.env.KUBERNETES_HOST || "kubernetes.default.svc";
+export const kubernetesPort = parseInt(process.env.KUBERNETES_SERVICE_PORT || "443");
 export const caCert = process.env.CA_CERT || "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
 export const serviceAccountTokenPath = process.env.SERVICEACCOUNT_TOKEN_PATH || "/var/run/secrets/kubernetes.io/serviceaccount/token";
 
@@ -57,7 +58,7 @@ export class K8sClient {
   }
 
   async patch<T>(path: string, obj: Object, headers = {}) {
-    const response = await got.patch(`https://${kubernetesHost}${path}`, {
+    const response = await got.patch(`https://${kubernetesHost}:${kubernetesPort}${path}`, {
       headers: {
         ...this.headers,
         ...headers


### PR DESCRIPTION
K8sClient did not use `KUBERNETES_SERVICE_PORT` at all, this PR fixes it.