### PR TITLE
Handle error when data is being written to a closing websocket

### DIFF
--- a/src/agent-proxy.ts
+++ b/src/agent-proxy.ts
@@ -94,6 +94,16 @@ export class AgentProxy {
 
       const wsDuplex = WebSocket.createWebSocketStream(this.ws);
 
+      wsDuplex.on("error", (error) => {
+        // wsDuplex may emit error when data is being written to the websocket which is already closing.
+        // In these cases we ignore the error as ws will retry on "close" event.
+        if (!String(error?.message).includes("WebSocket is not open")) {
+          throw error;
+        } else {
+          logger.warn("[PROXY] Duplex stream error: WebSocket is not open.");
+        }
+      });
+
       this.mplex.pipe(wsDuplex).pipe(this.mplex);
     });
 


### PR DESCRIPTION
* Fixes (hopefully) https://github.com/lensapp/bored-agent/issues/199

I managed to reproduce the same error with this code:
```
        this.ws?.close();
        this.mplex?.write("testdatachunk");
```

I'm not 100% sure the error is coming from this socket as the stacktrace is a bit ambiguous.

I tried to write a regression test for this but couldn't really simulate the error condition.