### PR TITLE
Handle malformed AUTO_UPDATE_URL, fallback to LENS_BACKEND_URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build-image": "docker build -t bored-agent:latest ."
   },
   "devDependencies": {
+    "@types/is-url": "^1.2.30",
     "@types/jest": "^27.0.2",
     "@types/jsonwebtoken": "^8.5.8",
     "@types/lodash": "^4.14.178",
@@ -34,6 +35,7 @@
     "got": "^11.8.5",
     "http-parser-js": "^0.5.5",
     "https-proxy-agent": "^5.0.0",
+    "is-url": "^1.2.4",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
     "pino": "^6.13.2",

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -1,6 +1,7 @@
 import * as k8s from "@kubernetes/client-node";
 import type { KubeConfig } from "@kubernetes/client-node";
 import got from "got";
+import isUrl from "is-url";
 
 /**
  * bored-agent updater.
@@ -89,10 +90,16 @@ function getConfig() {
 
 type Config = ReturnType<typeof getConfig>;
 
+function getBoredAgentUrl(AUTO_UPDATE_URL: string | undefined, LENS_BACKEND_URL: string | undefined) {
+  const url = isUrl(AUTO_UPDATE_URL ?? "") ?
+    AUTO_UPDATE_URL as string :
+    `${LENS_BACKEND_URL}/bored-agent/v2/bored-agent.yml`;
+
+  return url;
+}
+
 async function fetchBoredAgentYml(config: Config) {
-  const url = config.AUTO_UPDATE_URL ?
-    config.AUTO_UPDATE_URL :
-    `${config.LENS_BACKEND_URL}/bored-agent/v2/bored-agent.yml`;
+  const url = getBoredAgentUrl(config.AUTO_UPDATE_URL, config.LENS_BACKEND_URL);
 
   console.log(`Fetching bored-agent.yml from ${url}`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -712,6 +712,11 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
   integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
 
+"@types/is-url@^1.2.30":
+  version "1.2.30"
+  resolved "https://registry.yarnpkg.com/@types/is-url/-/is-url-1.2.30.tgz#85567e8bee4fee69202bc3448f9fb34b0d56c50a"
+  integrity sha512-AnlNFwjzC8XLda5VjRl4ItSd8qp8pSNowvsut0WwQyBWHpOxjxRJm8iO6uETWqEyLdYdb9/1j+Qd9gQ4l5I4fw==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -2794,6 +2799,11 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
 is-windows@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
* `AUTO_UPDATE_URL` may be malformed in some bored-agent deployments. Improve handling and avoid throwing and using the malformed url instead falling back to `LENS_BACKEND_URL`