### PR TITLE
Avoid error on missing LENS_BACKEND_URL

### DIFF
--- a/src/updater.ts
+++ b/src/updater.ts
@@ -79,12 +79,6 @@ function getConfig() {
     LENS_BACKEND_URL: process.env.LENS_BACKEND_URL
   };
 
-  const missingConfiguration = Object.entries(config).find(([, value]) => !value);
-
-  if (missingConfiguration) {
-    throw new Error(`Environment variable ${missingConfiguration[0]} not set`);
-  }
-
   return config;
 }
 


### PR DESCRIPTION
* This validation causes lots of issues since LENS_BACKEND_URL might be missing (as it's deprecated).