### PR TITLE
Remove insecure mode if no ca is given

### DIFF
--- a/src/__tests__/agent-proxy.test.ts
+++ b/src/__tests__/agent-proxy.test.ts
@@ -1,18 +1,32 @@
 import { Agents } from "got/dist/source";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { AgentProxy } from "../agent-proxy";
+import { PassThrough } from "stream";
+import { Stream } from "bored-mplex";
 
 describe("AgentProxy", () => {
   const OLD_ENV = process.env;
   let agent: AgentProxy;
+  let connect: any;
 
   beforeEach(() => {
     jest.resetModules();
+    connect = jest.fn((_opts: any, callback: () => void) => {
+      process.nextTick(() => {
+        callback();
+      });
+
+      return new PassThrough();
+    });
     process.env = { ...OLD_ENV };
     agent = new AgentProxy({
       boredServer: "https://bored.acme.org",
       boredToken: "foo.bar.baz",
       idpPublicKey: "this-is-not-valid"
+    }, { 
+      tlsConnect: connect,
+      fileExists: jest.fn(() => false),
+      readFile: jest.fn(),
     });
   });
 
@@ -51,6 +65,80 @@ describe("AgentProxy", () => {
 
       expect(agent.buildGotOptions().agent).toBeDefined();
       expect((agent.buildGotOptions().agent as Agents).https).toBeInstanceOf(HttpsProxyAgent);
+    });
+  });
+
+  describe("handleDefaultRequestStream", () => {
+    it("opens TLS socket with correct options", () => {
+      const stream = new Stream(1, {} as any);
+
+      agent.handleDefaultRequestStream(stream);
+
+      expect(connect).toHaveBeenCalledWith(expect.objectContaining({
+        host: "kubernetes.default.svc",
+        port: 443,
+        timeout: 1800000,
+      }), expect.any(Function));
+    });
+
+    describe("given CA file exists", () => {
+      beforeEach(() => {
+        agent = new AgentProxy({
+          boredServer: "https://bored.acme.org",
+          boredToken: "foo.bar.baz",
+          idpPublicKey: "this-is-not-valid"
+        }, { 
+          tlsConnect: connect,
+          fileExists: jest.fn(() => true),
+          readFile: jest.fn(() => Buffer.from("fake-ca") as any),
+        });
+      });
+
+      it("passes CA to TLS socket", () => {
+        const stream = new Stream(1, {} as any);
+
+        agent.handleDefaultRequestStream(stream);
+
+        expect(connect).toHaveBeenCalledWith(expect.objectContaining({
+          host: "kubernetes.default.svc",
+          port: 443,
+          ca: expect.any(Buffer),
+        }), expect.any(Function));
+      });
+    });
+
+    describe("given CA file does not exist", () => {
+      beforeEach(() => {
+        agent = new AgentProxy({
+          boredServer: "https://bored.acme.org",
+          boredToken: "foo.bar.baz",
+          idpPublicKey: "this-is-not-valid"
+        }, { 
+          tlsConnect: connect,
+          fileExists: jest.fn(() => false),
+          readFile: jest.fn(),
+        });
+      });
+
+      it("does not pass CA to TLS socket", () => {
+        const stream = new Stream(1, {} as any);
+
+        agent.handleDefaultRequestStream(stream);
+
+        expect(connect).toHaveBeenCalledWith(expect.not.objectContaining({
+          ca: expect.anything(),
+        }), expect.any(Function));
+      });
+
+      it("does not configure 'reject unauthorized' to TLS socket", () => {
+        const stream = new Stream(1, {} as any);
+
+        agent.handleDefaultRequestStream(stream);
+
+        expect(connect).toHaveBeenCalledWith(expect.not.objectContaining({
+          rejectUnauthorized: false,
+        }), expect.any(Function));
+      });
     });
   });
 });


### PR DESCRIPTION
Insecure mode was never meant to be used (outside of testing), better just to drop it completely.