### PR TITLE
fix: Update node version, reduce CVE's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye-slim as build
+FROM node:18-bullseye-slim as build
 
 RUN mkdir /app
 WORKDIR /app
@@ -8,7 +8,7 @@ RUN apt-get update -y -q && apt-get install -y -q gcc g++ make python3 && \
     yarn dist && \
     yarn install --frozen-lockfile --prod
 
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
Customer reported vulnerability CVE-2023-4911 is found in bored-agent

This is not present in `node:18-bullseye-slim`

Running trivy with old vs new:

OLD `node:16-bullseye-slim`:
```
quay.io/k8slens/bored-agent:0.11.0 (debian 11.7)
================================================
Total: 150 (UNKNOWN: 0, LOW: 76, MEDIUM: 39, HIGH: 33, CRITICAL: 2)

Node.js (node-pkg)
==================
Total: 8 (UNKNOWN: 0, LOW: 0, MEDIUM: 7, HIGH: 1, CRITICAL: 0)
```

NEW `node:18-bullseye-slim`:

```
new-bored:latest (debian 11.9)
==============================
Total: 128 (UNKNOWN: 0, LOW: 74, MEDIUM: 32, HIGH: 20, CRITICAL: 2)

Node.js (node-pkg)
==================
Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 0, CRITICAL: 0)
```

Installed locally built image to a cluster and tested the connection through spaces. Worked fine.

Fixes https://github.com/lensapp/lens-desktop-monorepo/issues/2326