### PR TITLE
Run tests on Node v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
       - name: Checkout Release
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR fixes error when installing dependencies for tests: 
```
error jsonpath-plus@10.2.0: The engine "node" is incompatible with this module. Expected version ">=18.0.0". Got "16.20.2"
error Found incompatible module.
```