### PR TITLE
fix: writing byte one at a time

### DIFF
--- a/src/__tests__/__snapshots__/stream-impersonator.test.ts.snap
+++ b/src/__tests__/__snapshots__/stream-impersonator.test.ts.snap
@@ -47,6 +47,17 @@ impersonate-user: johndoe
 BarÄö"
 `;
 
+exports[`StreamImpersonator handles binary data in body one byte at a time 1`] = `
+"POST / HTTP/1.1
+accept: application/json
+content-type: application/octet-stream
+content-length: 4
+authorization: Bearer service-account-token
+impersonate-user: johndoe
+
+Äö"
+`;
+
 exports[`StreamImpersonator handles body separator splitted to separate chunks 1`] = `
 "GET / HTTP/1.1
 accept: application/json

--- a/src/__tests__/stream-utils.ts
+++ b/src/__tests__/stream-utils.ts
@@ -1,0 +1,114 @@
+import { removeBytesFromBuffersHead } from "../stream-utils";
+
+describe("stream-utils", () => {
+  describe("removeBytesFromBuffersHead", () => {
+    describe("no buffers", () => {
+      describe("zero bytes to remove", () => {
+        it("removes nothing", () => {
+          expect(removeBytesFromBuffersHead([], 0)).toEqual([]);
+        });
+      });
+
+      describe("one byte to remove", () => {
+        it("removes nothing", () => {
+          expect(removeBytesFromBuffersHead([], 0)).toEqual([]);
+        });
+      });
+
+      describe("minutes 1 byte to remove", () => {
+        it("removes nothing", () => {
+          expect(removeBytesFromBuffersHead([], -1)).toEqual([]);
+        });
+      });
+    });
+
+    describe("one buffer", () => {
+      describe("has one byte", () => {
+        it("is removed completely", () => {
+          const buffer = Buffer.from([0x01]);
+
+          expect(removeBytesFromBuffersHead([buffer], 1)).toEqual([]);
+        });
+      });
+
+      describe("has one byte and removes 2", () => {
+        it("is removed completely", () => {
+          const buffer = Buffer.from([0x01]);
+
+          expect(removeBytesFromBuffersHead([buffer], 2)).toEqual([]);
+        });
+      });
+
+      describe("has empty buffer", () => {
+        it("is removed completely", () => {
+          const buffer = Buffer.from([]);
+
+          expect(removeBytesFromBuffersHead([buffer], 1)).toEqual([]);
+        });
+      });
+
+      describe("bytes to remove matches last buffer length", () => {
+        it("is removed completely", () => {
+          const buffer = Buffer.from([0x01, 0x02, 0x03]);
+
+          expect(removeBytesFromBuffersHead([buffer], 3)).toEqual([]);
+        });
+      });
+
+      describe("bytes to remove doesn't match last buffer length", () => {
+        it("is removed partially", () => {
+          const buffer = Buffer.from([0x01, 0x02, 0x03]);
+
+          expect(removeBytesFromBuffersHead([buffer], 2)).toEqual([Buffer.from([0x03])]);
+        });
+      });
+    });
+
+    describe("many buffers", () => {
+      describe("bytes to remove matches last buffer length", () => {
+        it("first buffer is removed completely", () => {
+          const buffer1 = Buffer.from([0x01, 0x02, 0x03]);
+          const buffer2 = Buffer.from([0x04, 0x05, 0x06]);
+
+          expect(removeBytesFromBuffersHead([buffer1, buffer2], 3)).toEqual([buffer2]);
+        });
+      });
+
+      describe("bytes to remove is less than last buffer length", () => {
+        it("is removed partially", () => {
+          const buffer1 = Buffer.from([0x01, 0x02, 0x03]);
+          const buffer2 = Buffer.from([0x04, 0x05, 0x06]);
+
+          expect(removeBytesFromBuffersHead([buffer1, buffer2], 2)).toEqual([ Buffer.from([0x03]), buffer2]);
+        });
+      });
+
+      describe("bytes to remove is more than last buffer length", () => {
+        it("is removed partially", () => {
+          const buffer1 = Buffer.from([0x01, 0x02, 0x03]);
+          const buffer2 = Buffer.from([0x04, 0x05, 0x06]);
+
+          expect(removeBytesFromBuffersHead([buffer1, buffer2], 4)).toEqual([Buffer.from([0x05, 0x06])]);
+        });
+      });
+
+      describe("bytes to remove is equal to sum of all buffer lengths", () => {
+        it("is removed completely", () => {
+          const buffer1 = Buffer.from([0x01, 0x02, 0x03]);
+          const buffer2 = Buffer.from([0x04, 0x05, 0x06]);
+
+          expect(removeBytesFromBuffersHead([buffer1, buffer2], 6)).toEqual([]);
+        });
+      });
+
+      describe("bytes to remove is more than the sum of all buffer lengths", () => {
+        it("is removed completely", () => {
+          const buffer1 = Buffer.from([0x01, 0x02, 0x03]);
+          const buffer2 = Buffer.from([0x04, 0x05, 0x06]);
+
+          expect(removeBytesFromBuffersHead([buffer1, buffer2], 9999)).toEqual([]);
+        });
+      });
+    });
+  });
+});

--- a/src/stream-utils.ts
+++ b/src/stream-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Removes bytes from the beginning of the buffers array.
+ * If bytes to be removed is less than the buffer length, the bytes are removed from the start
+ * of the buffer.
+ * @param buffers Array of buffers to reduce
+ * @param bytes Number of bytes to remove.
+ * @returns 
+ */
+export const removeBytesFromBuffersHead = (buffers: Buffer[], bytes: number) => {
+  let bytesToRemove = bytes;
+
+  while (bytesToRemove > 0 && buffers.length > 0) {
+    const firstBuffer = buffers[0];
+
+    if (bytesToRemove < firstBuffer.length) {
+      // Remove 'bytesToRemove' from the start of the last buffer
+      buffers[0] = firstBuffer.subarray(bytesToRemove);
+
+      bytesToRemove = 0;
+    } else {
+      buffers.shift();
+      bytesToRemove -= firstBuffer.length;
+    }
+  }
+
+  return buffers;
+};


### PR DESCRIPTION
* Parsing was failing if bytes were written one by one since we convert partial UTF-8 characters (for example) into string