### PR TITLE
feat: configurable log level

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,11 +1,14 @@
 import pino from "pino";
 
+export const logLevel = process.env.LOG_LEVEL || "info";
+
 const logger = pino({
+  level: logLevel,
   transport: {
     target: "pino-pretty",
     options: {
       ignore: "pid,hostname",
-      translateTime: true,
+      translateTime: true
     },
   },
 });

--- a/src/stream-impersonator.ts
+++ b/src/stream-impersonator.ts
@@ -2,7 +2,7 @@ import { Transform, TransformCallback } from "stream";
 import { HTTPParser, HTTPParserJS } from "http-parser-js";
 import { chunk } from "lodash";
 import * as jwt from "jsonwebtoken";
-import logger from "./logger";
+import logger, { logLevel } from "./logger";
 import { removeBytesFromBuffersHead } from "./stream-utils";
 
 type TokenPayload = {
@@ -107,6 +107,10 @@ export class StreamImpersonator extends Transform {
     _encoding: BufferEncoding,
     callback: TransformCallback,
   ): void {
+    if (logLevel === "trace") {
+      console.log(chunk.toString("utf8"));
+    }
+
     if (this.upgrade) {
       this.push(chunk);
 


### PR DESCRIPTION
* Add support for `LOG_LEVEL` environment variable to log specify level as defined in `pino` documentation.
* Default log leve is `"info"` as before.
* Add support to log all chunks if log level is `"trace"`