### PR TITLE
fix: chunked data

### DIFF
--- a/src/__tests__/__snapshots__/stream-impersonator.test.ts.snap
+++ b/src/__tests__/__snapshots__/stream-impersonator.test.ts.snap
@@ -206,3 +206,35 @@ impersonate-user: johndoe
 
 "
 `;
+
+exports[`StreamImpersonator transfer encoding chunked 1`] = `
+"GET /version HTTP/1.1
+host: 127.0.0.1:53364
+user-agent: node-fetch
+accept: */*
+accept-encoding: gzip, deflate, br
+x-forwarded-for: 127.0.0.1
+authorization: Bearer service-account-token
+impersonate-user: johndoe
+impersonate-group: dev
+impersonate-group: ops
+
+POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews HTTP/1.1
+host: 127.0.0.1:53364
+user-agent: node-fetch
+transfer-encoding: chunked
+accept: */*
+accept-encoding: gzip, deflate, br
+content-type: application/json
+x-forwarded-for: 127.0.0.1
+authorization: Bearer service-account-token
+impersonate-user: johndoe
+impersonate-group: dev
+impersonate-group: ops
+
+b0
+{"spec":{"resourceAttributes":{"namespace":"kube-system","resource":"*","verb":"create"}},"kind":"SelfSubjectAccessReview","apiVersion":"authorization.k8s.io/v1","metadata":{}}
+0
+
+"
+`;


### PR DESCRIPTION
* Fixes regression in https://github.com/lensapp/bored-agent/pull/313, which caused the stream-impersonator to not send all bytes that are not part of the body or headers, which would caused chunked transfer encoding to break, as we need those extra bytes to specify the chunk sizes
* The fix is to wait until headers are received, only parse the header bytes and then parse the rest of the bytes as normal
* Adds regression test to ensure transfer encoding chunked works correctly