### PR TITLE
chore: bump base image to node:22-bookworm-slim and patch vulnerable deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - name: Checkout Release
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bullseye-slim as build
+FROM node:22-trixie-slim AS build
 
 RUN mkdir /app
 WORKDIR /app
@@ -8,7 +8,7 @@ RUN apt-get update -y -q && apt-get install -y -q gcc g++ make python3 && \
     yarn dist && \
     yarn install --frozen-lockfile --prod
 
-FROM node:20-bullseye-slim
+FROM node:22-trixie-slim
 
 RUN mkdir /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,20 @@
-FROM node:22-trixie-slim AS build
+FROM node:22-bookworm-slim AS build
 
 RUN mkdir /app
 WORKDIR /app
 COPY . /app
-RUN apt-get update -y -q && apt-get install -y -q gcc g++ make python3 && \
+RUN apt-get update -y -q && \
+    apt-get upgrade -y -q && \
+    apt-get install -y -q gcc g++ make python3 && \
     yarn install --frozen-lockfile && \
     yarn dist && \
     yarn install --frozen-lockfile --prod
 
-FROM node:22-trixie-slim
+FROM node:22-bookworm-slim
 
+RUN apt-get update -y -q && \
+    apt-get upgrade -y -q && \
+    rm -rf /var/lib/apt/lists/*
 RUN mkdir /app
 WORKDIR /app
 COPY package.json yarn.lock ./

--- a/package.json
+++ b/package.json
@@ -40,10 +40,15 @@
     "https-proxy-agent": "^7.0.6",
     "is-url": "^1.2.4",
     "jsonwebtoken": "^9.0.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "ws": "^8.18.0",
     "yaml": "^2.3.4"
+  },
+  "resolutions": {
+    "jws": "^3.2.3",
+    "picomatch": "^4.0.4",
+    "micromatch/picomatch": "^2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bored-agent",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Bored Agent",
   "main": "dist/index.js",
   "author": "Mirantis Inc.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,9 +1039,9 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-buffer-equal-constant-time@1.0.1:
+buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
 cac@^6.7.14:
@@ -1879,21 +1879,21 @@ jsonwebtoken@^9.0.0:
     ms "^2.1.1"
     semver "^7.5.4"
 
-jwa@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz"
-  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+jwa@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.2.tgz#16011ac6db48de7b102777e57897901520eec7b9"
+  integrity sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==
   dependencies:
-    buffer-equal-constant-time "1.0.1"
+    buffer-equal-constant-time "^1.0.1"
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz"
-  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+jws@^3.2.2, jws@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.3.tgz#5ac0690b460900a27265de24520526853c0b8ca1"
+  integrity sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==
   dependencies:
-    jwa "^1.4.1"
+    jwa "^1.4.2"
     safe-buffer "^5.0.1"
 
 keyv@^4.0.0, keyv@^4.5.4:
@@ -1958,10 +1958,10 @@ lodash.once@^4.0.0:
   resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@^4.18.0:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 loupe@^3.1.0, loupe@^3.1.3:
   version "3.1.3"
@@ -2231,15 +2231,15 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@^2.3.1, picomatch@^4.0.2, picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
-picomatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz"
-  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+picomatch@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pino-abstract-transport@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

Addresses the vulnerabilities reported by `trivy image --severity HIGH,CRITICAL --ignore-unfixed quay.io/k8slens/bored-agent:0.13.0` — **1 CRITICAL + 22 HIGH**.

- Bumps the Dockerfile base image from `node:20-bullseye-slim` (Debian 11, now in extended LTS only) to `node:22-bookworm-slim` (Debian 12).
- Adds `apt-get update && apt-get upgrade` in both build and runtime stages so security-only patches (e.g. the libgnutls30 `+deb12u7` rebuild) are pulled in at build time rather than waiting on the upstream Node Docker image to be refreshed.
- Updates the CI test matrix to `node 22.x` to match the new runtime.
- Bumps `lodash` to `^4.18.0` (direct dep) and adds yarn `resolutions` for `jws >= 3.2.3` and `picomatch >= 4.0.4`, with a nested `micromatch/picomatch` resolution to keep `micromatch` on the patched v2 line (`2.3.2`).

### Note on the base image choice

The first attempt used `node:22-trixie-slim` (Debian 13), which is cleaner from a CVE standpoint, but Debian 13 dropped armhf as a release architecture so the image does not publish a `linux/arm/v7` variant. The CI matrix builds for `linux/amd64,linux/arm64,linux/arm` and the published `quay.io/k8slens/bored-agent:0.13.0` ships an armv7 image, so trixie would have broken downstream armv7 consumers. Bookworm + apt-upgrade gives equivalent CVE coverage without dropping armv7.

## Vulnerabilities cleared

### OS — Debian 11 bullseye (8 HIGH)

| CVE | Package | Fixed in |
|---|---|---|
| CVE-2025-32988 | libgnutls30 | 3.7.1-5+deb11u8 |
| CVE-2025-32990 | libgnutls30 | 3.7.1-5+deb11u8 |
| CVE-2025-4802 | libc-bin | 2.31-13+deb11u13 |
| CVE-2025-6020 | libpam-modules | 1.4.0-9+deb11u2 |
| CVE-2025-68973 | gpgv | 2.2.27-2+deb11u3 |
| CVE-2025-69419 | libssl1.1 | 1.1.1w-0+deb11u5 |
| CVE-2025-69421 | libssl1.1 | 1.1.1w-0+deb11u5 |
| CVE-2026-29111 | libsystemd0 | 247.3-7+deb11u8 |

All resolved by moving to bookworm (`libssl1.1` no longer exists; bookworm ships OpenSSL 3).

### OS — Debian 12 bookworm carry-over (2 CRITICAL + 4 HIGH)

These appeared on a bare `node:22-bookworm-slim` scan because the upstream Node Docker image still bakes in `libgnutls30 3.7.9-2+deb12u6`. The fixed `+deb12u7` is already live in `bookworm-security` and is pulled in by the new `apt upgrade` step.

| CVE | Severity | Package | Fixed in |
|---|---|---|---|
| CVE-2026-33845 | CRITICAL | libgnutls30 | 3.7.9-2+deb12u7 |
| CVE-2026-42010 | CRITICAL | libgnutls30 | 3.7.9-2+deb12u7 |
| CVE-2026-33846 | HIGH | libgnutls30 | 3.7.9-2+deb12u7 |
| CVE-2026-3833 | HIGH | libgnutls30 | 3.7.9-2+deb12u7 |
| CVE-2026-42009 | HIGH | libgnutls30 | 3.7.9-2+deb12u7 |
| CVE-2026-42011 | HIGH | libgnutls30 | 3.7.9-2+deb12u7 |

### Node dependencies (1 CRITICAL + 14 HIGH)

| CVE | Severity | Package | Installed → Fixed | How fixed |
|---|---|---|---|---|
| CVE-2025-7783 | CRITICAL | form-data | 4.0.3 → 4.0.4 | Already merged on main (#379) |
| CVE-2024-21538 | HIGH | cross-spawn | 7.0.3 → 7.0.5 | Cleared by Node 22 transitive resolution |
| CVE-2025-59343 | HIGH | tar-fs | 3.0.9 → 3.1.1 | Already merged on main (#394) |
| CVE-2025-64756 | HIGH | glob | 10.4.2 → 10.5.0 | Cleared by Node 22 transitive resolution |
| CVE-2025-65945 | HIGH | jws | 3.2.2 → 3.2.3 | `resolutions` entry |
| CVE-2026-23745 | HIGH | tar | 6.2.1 → 7.5.3 | Cleared by Node 22 transitive resolution |
| CVE-2026-23950 | HIGH | tar | 6.2.1 → 7.5.4 | Cleared by Node 22 transitive resolution |
| CVE-2026-24842 | HIGH | tar | 6.2.1 → 7.5.7 | Cleared by Node 22 transitive resolution |
| CVE-2026-26960 | HIGH | tar | 6.2.1 → 7.5.8 | Cleared by Node 22 transitive resolution |
| CVE-2026-29786 | HIGH | tar | 6.2.1 → 7.5.10 | Cleared by Node 22 transitive resolution |
| CVE-2026-31802 | HIGH | tar | 6.2.1 → 7.5.11 | Cleared by Node 22 transitive resolution |
| CVE-2026-26996 | HIGH | minimatch | 9.0.5 → 9.0.6 | Cleared by Node 22 transitive resolution |
| CVE-2026-27903 | HIGH | minimatch | 9.0.5 → 9.0.7 | Cleared by Node 22 transitive resolution |
| CVE-2026-27904 | HIGH | minimatch | 9.0.5 → 9.0.7 | Cleared by Node 22 transitive resolution |
| CVE-2026-4800 | HIGH | lodash | 4.17.21 → 4.18.0 | Direct dep bump |
| CVE-2026-33671 | HIGH | picomatch | 4.0.3 → 4.0.4 | `resolutions` entry (with `micromatch/picomatch` nested to 2.3.2) |

## Scan results

| Image | CRITICAL | HIGH |
|---|---|---|
| `quay.io/k8slens/bored-agent:0.13.0` | 1 | 22 |
| Local build of this PR | 0 | 1* |

\* The remaining HIGH is `picomatch 4.0.3` bundled inside the `npm` install at `/usr/local/lib/node_modules/npm/...` in the upstream `node:22-bookworm-slim` image. It is **not** in bored-agent's runtime tree — the container's entrypoint is `node /app/dist/index.js` and `npm` is never invoked at runtime, so the ReDoS vector is unreachable. It will clear when the upstream Node Docker image is rebuilt against a newer npm.

## Test plan

- [x] CI: lint + tests pass on Node 22
- [x] CI: multi-arch image build succeeds (`linux/amd64,linux/arm64,linux/arm`)
- [ ] Post-merge: rebuild and rescan published image, confirm 0 CRITICAL / 1 HIGH (upstream-only)
